### PR TITLE
Fixes client-side routing

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Route} from 'react-router-dom'
+import {Route, withRouter} from 'react-router-dom'
 import {connect} from 'react-redux'
 
 import Header from './Header'
@@ -34,4 +34,4 @@ const mapStateToProps = (state) => {
   }
 }
 
-export default connect(mapStateToProps)(App)
+export default withRouter(connect(mapStateToProps)(App))

--- a/client/components/NewPing.jsx
+++ b/client/components/NewPing.jsx
@@ -1,5 +1,6 @@
-import {connect} from 'react-redux'
 import React from 'react'
+import {connect} from 'react-redux'
+
 import {postPingAsync} from '../actions/pings'
 
 class NewPing extends React.Component {

--- a/client/components/Pings.jsx
+++ b/client/components/Pings.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {connect} from 'react-redux'
+
 import {fetchPings} from '../actions/pings'
 import Ping from './Ping'
 

--- a/client/components/Profile.jsx
+++ b/client/components/Profile.jsx
@@ -1,5 +1,5 @@
-import { connect } from 'react-redux'
 import React from 'react'
+import {connect} from 'react-redux'
 
 import {updateProfile} from '../actions/pings.js'
 

--- a/client/components/Register.jsx
+++ b/client/components/Register.jsx
@@ -1,5 +1,5 @@
-import { connect } from 'react-redux'
 import React from 'react'
+import {connect} from 'react-redux'
 
 class Register extends React.Component {
   constructor (props) {


### PR DESCRIPTION
The only important change is in `App.jsx` where `withRouter` is imported and used. That fixes the routing issues we were seeing.

The cause: react-redux's `connect()` call prevents the state changes from 'route change' events from ever making their way to a render call. The `withRouter` call allows those route changes to call a render.

The other file changes are just my OCD getting the better of me 😭  